### PR TITLE
make id labels red, larger

### DIFF
--- a/code/extraction.py
+++ b/code/extraction.py
@@ -840,7 +840,7 @@ if __name__ == "__main__":
     )
     for i in (0, 1, 2):
         for k in range(rois.shape[0]):
-            ax[i].text(*cm[k], str(k), color="orange", fontsize=8 * lw)
+            ax[i].text(*cm[k], str(k), color="red", fontsize=14 * lw)
     plt.savefig(
         output_dir / f"{unique_id}_detected_ROIs_withIDs.png",
         bbox_inches="tight",

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -840,7 +840,7 @@ if __name__ == "__main__":
     )
     for i in (0, 1, 2):
         for k in range(rois.shape[0]):
-            ax[i].text(*cm[k], str(k), color="red", fontsize=14 * lw)
+            ax[i].text(*cm[k], str(k), color="red", fontsize=12 * lw)
     plt.savefig(
         output_dir / f"{unique_id}_detected_ROIs_withIDs.png",
         bbox_inches="tight",


### PR DESCRIPTION
Changing color (orange -> red), increasing font size (8 -> 12) of ROI ID labels.

Example of current ID labels below.

![image](https://github.com/user-attachments/assets/f925cc8c-5297-407b-b5d8-b6223ceae1e6)


