### PR TITLE
Migrate to Suite2p 1.1.0 and Cellpose 4.0 (Cellpose-SAM)

### DIFF
--- a/code/extraction.py
+++ b/code/extraction.py
@@ -16,6 +16,7 @@ import numpy as np
 import skimage
 import sparse
 import suite2p
+import torch
 from aind_data_schema.core.processing import DataProcess, ProcessName
 from aind_data_schema.core.quality_control import QCMetric, QCStatus, Status
 from aind_log_utils.log import setup_logging
@@ -28,7 +29,6 @@ from aind_ophys_utils.summary_images import (
 )
 from aind_qcportal_schema.metric_value import CheckboxMetric
 from caiman.source_extraction.cnmf import cnmf, params
-from cellpose.models import Cellpose
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from scipy.sparse import coo_matrix, hstack, linalg
@@ -121,10 +121,10 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
         ),
     )
     pretrained_model: str = Field(
-        default="cyto",
+        default="cpsam_v2",
         description=(
-            "CellPose pretrained model to use. Common options: 'cyto' (standard model), "
-            "'cyto2' (improved model), or path to a custom model file."
+            "CellPose pretrained model to use. Common options: 'cpsam_v2' or 'cpsam' "
+            "(Cellpose-SAM foundation models), or path to a custom model file."
         ),
     )
     # Neuropil parameters
@@ -769,7 +769,57 @@ def get_contours(
     return coordinates
 
 
-def estimate_gSig(diameter: float, img: np.ndarray, fac: float = 2.35482) -> float:
+def estimate_diameter(
+    img: np.ndarray,
+    pretrained_model: str,
+    cellprob_threshold: float = 0.0,
+    flow_threshold: float = 0.4,
+) -> float:
+    """Estimate cell diameter by running Cellpose detection and measuring its masks.
+
+    Cellpose-SAM (cellpose>=4.0.1) dropped the standalone SizeModel used by the
+    pre-4.0 ``Cellpose`` wrapper class, so there is no cheap way to estimate
+    diameter without running full detection. This reuses Suite2p's own
+    Cellpose call (``suite2p.detection.anatomical.roi_detect``) and takes the
+    median diameter it already computes from the detected masks.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image to run Cellpose detection on (e.g. mean image).
+    pretrained_model : str
+        Name of the Cellpose pretrained model, or path to a custom model file.
+    cellprob_threshold : float
+        Cellpose cell probability threshold.
+    flow_threshold : float
+        Cellpose flow threshold.
+
+    Returns
+    -------
+    float
+        Median diameter (in pixels) across detected masks.
+    """
+    _, _, median_diam, _ = suite2p.detection.anatomical.roi_detect(
+        img,
+        settings={
+            "params": None,
+            "cellprob_threshold": cellprob_threshold,
+            "flow_threshold": flow_threshold,
+        },
+        pretrained_model=pretrained_model,
+        device=torch.device("cpu"),
+    )
+    return median_diam
+
+
+def estimate_gSig(
+    diameter: float,
+    img: np.ndarray,
+    pretrained_model: str,
+    cellprob_threshold: float = 0.0,
+    flow_threshold: float = 0.4,
+    fac: float = 2.35482,
+) -> float:
     """Estimate Gaussian sigma for CaImAn based on cell diameter.
 
     Parameters
@@ -778,6 +828,12 @@ def estimate_gSig(diameter: float, img: np.ndarray, fac: float = 2.35482) -> flo
         Cell diameter in pixels; if 0, it will be automatically estimated with Cellpose.
     img : np.ndarray
         Mean image used for automatic diameter estimation if needed.
+    pretrained_model : str
+        Cellpose pretrained model to use for automatic diameter estimation if needed.
+    cellprob_threshold : float
+        Cellpose cell probability threshold, used for automatic diameter estimation.
+    flow_threshold : float
+        Cellpose flow threshold, used for automatic diameter estimation.
     fac : float
         Factor by which to divide Cellpose's diameter estimate.
         Based on jGCaMP data, a value between 2 and 2.5 is a good choice.
@@ -789,7 +845,9 @@ def estimate_gSig(diameter: float, img: np.ndarray, fac: float = 2.35482) -> flo
         Estimated Gaussian sigma.
     """
     if diameter == 0:
-        diameter = Cellpose().sz.eval(img)[0]
+        diameter = estimate_diameter(
+            img, pretrained_model, cellprob_threshold, flow_threshold
+        )
         logger.info(
             f"'diameter' set to 0 — automatically estimated with Cellpose as {diameter:.3f}."
         )
@@ -907,7 +965,13 @@ def build_CNMFParams(
         Parameter dictionary for CaImAn
     """
     # Estimate Gaussian sigma based on cell diameter
-    gSig = estimate_gSig(args.diameter, ops["meanImg"])
+    gSig = estimate_gSig(
+        args.diameter,
+        ops["meanImg"],
+        args.pretrained_model,
+        args.cellprob_threshold,
+        args.flow_threshold,
+    )
 
     # Base parameters (common to both initialization methods)
     params_dict = {
@@ -1472,7 +1536,14 @@ if __name__ == "__main__":
         diameter = args.diameter
         if diameter == 0 and args.init == "sourcery":
             with h5py.File(str(motion_corrected_fn), "r") as open_vid:
-                diameter = round(Cellpose().sz.eval(mean_image(open_vid["data"]))[0])
+                diameter = round(
+                    estimate_diameter(
+                        mean_image(open_vid["data"]),
+                        args.pretrained_model,
+                        args.cellprob_threshold,
+                        args.flow_threshold,
+                    )
+                )
             logger.info(
                 "'diameter' set to 0 — automatically estimated with Cellpose "
                 f"as {diameter:.0f}."

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -1529,7 +1529,7 @@ if __name__ == "__main__":
         # Set suite2p db (paths) and settings (everything else).
         db = suite2p.default_db()
         db["input_format"] = "h5"
-        db["data_path"] = [motion_corrected_fn.parent]
+        db["data_path"] = [str(motion_corrected_fn.parent)]
         db["file_list"] = [str(motion_corrected_fn)]
         db["save_path0"] = str(tmp_dir)
         db["functional_chan"] = args.functional_chan
@@ -1563,8 +1563,8 @@ if __name__ == "__main__":
         # for Suite2P ROI detection purposes. This allows consistent temporal
         # downsampling across movies with different lengths and/or frame rates.
         bin_duration = 3.7
-        bin_size = round(bin_duration * frame_rate)
-        nbinned = int(nframes / bin_size)
+        bin_size = max(1, round(bin_duration * frame_rate))
+        nbinned = max(1, int(nframes / bin_size))
         logger.info(
             f"Movie has {nframes} frames collected at "
             f"{frame_rate} Hz. "
@@ -1675,8 +1675,10 @@ if __name__ == "__main__":
         try:
             input_args = {**vars(args), **db, **settings}
             suite2p.run_s2p(db, settings)
-        except ValueError:  # raised when no ROIs found
-            pass
+        except ValueError as e:
+            if "no ROIs were found" not in str(e):
+                raise
+            logger.warning(f"Suite2p found no ROIs: {e}")
 
         # load in the rois from the stat file and movie path for shape
         with h5py.File(str(motion_corrected_fn), "r") as open_vid:

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -1790,7 +1790,8 @@ if __name__ == "__main__":
             traces_roi, traces_neuropil, traces_corrected = [
                 np.empty((0, nframes), dtype=np.float32)
             ] * 3
-            r_values, data, coords, neuropil_coords, iscell = [[]] * 5
+            r_values, data, coords, neuropil_coords = [], [], [], []
+            iscell = np.empty((0, 2), dtype=np.float32)
             if args.neuropil == "mutualinfo":
                 raw_r = []
             keys = []

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -1144,7 +1144,8 @@ def format_caiman_output(
             ).astype("f4")
     else:
         traces_neuropil = e.A.T.dot(e.b).dot(e.f).astype("f4")
-        traces_corrected += 0.8 * traces_neuropil  # TODO: check factor on groundtruth data
+        # CNMF's model already separates C from the shared background b*f,
+        # so no further neuropil correction is applied here.
     traces_roi = (e.C + e.YrA + traces_neuropil).astype("f4")
     # convert ROIs to sparse COO 3D-tensor (https://sparse.pydata.org/en/stable/construct.html)
     data = []

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -83,7 +83,9 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
     )
     max_overlap: float = Field(
         default=0.75,
-        description="cells with more overlap than this get removed during triage, before refinement",
+        description=(
+            "cells with more overlap than this get removed during triage, before refinement"
+        ),
     )
     soma_crop: bool = Field(
         default=False,
@@ -91,13 +93,13 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
     )
     allow_overlap: bool = Field(
         default=False,
-        description="pixels that are overlapping are thrown out (False) or added to both ROIs (True)",
+        description=(
+            "pixels that are overlapping are thrown out (False) or added to both ROIs (True)"
+        ),
     )
     denoise: bool = Field(
         default=False,
-        description=(
-            "If True, applies denoising to the binned movie before cell detection."
-        ),
+        description=("If True, applies denoising to the binned movie before cell detection."),
     )
     cellprob_threshold: float = Field(
         default=0.0,
@@ -154,9 +156,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
     )
     nb: int = Field(
         default=2,
-        description=(
-            "Number of background components if using CaImAn with neuropil=cnmf."
-        ),
+        description=("Number of background components if using CaImAn with neuropil=cnmf."),
     )
     rf: int | None = Field(
         default=40,
@@ -189,8 +189,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
     ssub_B: int = Field(
         default=2,
         description=(
-            "Additional spatial downsampling factor for background "
-            "during CNMF-E processing."
+            "Additional spatial downsampling factor for background during CNMF-E processing."
         ),
     )
     merge_thr: float = Field(
@@ -308,9 +307,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
             )
 
         if self.neuropil == "cnmf-e" and self.init == "greedy_roi":
-            raise ValueError(
-                "Can't use neuropil model 'cnmf-e' with 'greedy_roi' initialization"
-            )
+            raise ValueError("Can't use neuropil model 'cnmf-e' with 'greedy_roi' initialization")
 
         if self.init in ("greedy_roi", "corr_pnr") and self.neuropil[:4] != "cnmf":
             raise ValueError(
@@ -319,7 +316,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
 
         return None  # No warning message
 
-    def model_post_init(self, _) -> None:
+    def model_post_init(self, _: object) -> None:
         """Run validation after model initialization"""
         warning = self.validate_consistency()
         if warning:
@@ -477,12 +474,8 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, num_rois: int) -> Non
     metric = QCMetric(
         name=f"{experiment_id} Detected ROIs",
         description="",
-        reference=str(
-            f"{experiment_id}/extraction/{experiment_id}_detected_ROIs_withIDs.png"
-        ),
-        status_history=[
-            QCStatus(evaluator="Automated", timestamp=dt.now(), status=Status.PASS)
-        ],
+        reference=str(f"{experiment_id}/extraction/{experiment_id}_detected_ROIs_withIDs.png"),
+        status_history=[QCStatus(evaluator="Automated", timestamp=dt.now(), status=Status.PASS)],
         value=CheckboxMetric(value=[], options=options, status=statuses),
     )
 
@@ -556,9 +549,7 @@ def bergamo_segmentation(motion_corr_fp: Path, session: dict, temp_dir: Path) ->
     frame_locations = [epoch_locations[i] for i in valid_epoch_stems]
     frames_length = sum([(i[1] - i[0] + 1) for i in frame_locations])
 
-    return create_virtual_dataset(
-        motion_corr_fp, frame_locations, frames_length, temp_dir
-    )
+    return create_virtual_dataset(motion_corr_fp, frame_locations, frames_length, temp_dir)
 
 
 def create_chunk_vds(start: int, chunksize: int, input_fn: str, tmp_dir: str) -> str:
@@ -585,9 +576,7 @@ def create_chunk_vds(start: int, chunksize: int, input_fn: str, tmp_dir: str) ->
         data = fin["data"]
         end = min(start + chunksize, data.shape[0])
         # Define the virtual layout for this chunk
-        layout = h5py.VirtualLayout(
-            shape=(end - start, *data.shape[1:]), dtype=data.dtype
-        )
+        layout = h5py.VirtualLayout(shape=(end - start, *data.shape[1:]), dtype=data.dtype)
         vsource = h5py.VirtualSource(input_fn, "data", shape=data.shape)
         layout[:] = vsource[start:end]
         # Create a VDS file for this chunk
@@ -743,9 +732,7 @@ def get_contours(
             if thr_method != "max":
                 logging.warning("Unknown threshold method. Choosing max")
             Bvec = np.zeros(d)
-            Bvec[A.indices[A.indptr[i] : A.indptr[i + 1]]] = (
-                patch_data / patch_data.max()
-            )
+            Bvec[A.indices[A.indptr[i] : A.indptr[i + 1]]] = patch_data / patch_data.max()
 
         Bmat = np.reshape(Bvec, dims, order="F")
         pars["coordinates"] = []
@@ -849,9 +836,7 @@ def estimate_gSig(
         Estimated Gaussian sigma.
     """
     if diameter == 0:
-        diameter = estimate_diameter(
-            img, pretrained_model, cellprob_threshold, flow_threshold
-        )
+        diameter = estimate_diameter(img, pretrained_model, cellprob_threshold, flow_threshold)
         logger.info(
             f"'diameter' set to 0 — automatically estimated with Cellpose as {diameter:.3f}."
         )
@@ -897,9 +882,7 @@ def get_r_from_min_mi(
     raw_trace[np.isnan(raw_trace)] = 0
     for r_i, r_temp in enumerate(r_iters):
         Fc = raw_trace - r_temp * neuropil_trace
-        mi_iters[r_i] = skimage.metrics.normalized_mutual_information(
-            Fc, neuropil_trace
-        )
+        mi_iters[r_i] = skimage.metrics.normalized_mutual_information(Fc, neuropil_trace)
     min_ind = np.argmin(mi_iters)
     r_best = r_iters[min_ind]
     return r_best, mi_iters, r_iters
@@ -930,10 +913,7 @@ def get_FC_from_r(
         1D array of r values that minimized the mutual information before thresholding.
     """
     r_values = np.array(
-        [
-            get_r_from_min_mi(raw_trace[i], neuropil_trace[i])[0]
-            for i in range(raw_trace.shape[0])
-        ]
+        [get_r_from_min_mi(raw_trace[i], neuropil_trace[i])[0] for i in range(raw_trace.shape[0])]
     )
     mean_r = np.mean(r_values[r_values < 1])
     if np.sum(r_values < 1) < min_r_count:
@@ -1153,26 +1133,18 @@ def format_caiman_output(
                 Atb0 + AtW.dot(Yr) - AtW.dot(e.A).dot(e.C) - AtW.dot(e.b0)[:, None]
             ).astype("f4")
         else:
-            ds_mat = caiman.source_extraction.cnmf.utilities.decimation_matrix(
-                e.dims, ssub_B
-            )
+            ds_mat = caiman.source_extraction.cnmf.utilities.decimation_matrix(e.dims, ssub_B)
             Ads = ds_mat.dot(e.A)
             b0ds = ds_mat.dot(e.b0)
             AtW = Ads.T.dot(e.W)
             traces_neuropil = (
                 Atb0
                 + ssub_B**2
-                * (
-                    AtW.dot(ds_mat).dot(Yr)
-                    - AtW.dot(Ads).dot(e.C)
-                    - AtW.dot(b0ds)[:, None]
-                )
+                * (AtW.dot(ds_mat).dot(Yr) - AtW.dot(Ads).dot(e.C) - AtW.dot(b0ds)[:, None])
             ).astype("f4")
     else:
         traces_neuropil = e.A.T.dot(e.b).dot(e.f).astype("f4")
-        traces_corrected += (
-            0.8 * traces_neuropil
-        )  # TODO: check factor on groundtruth data
+        traces_corrected += 0.8 * traces_neuropil  # TODO: check factor on groundtruth data
     traces_roi = (e.C + e.YrA + traces_neuropil).astype("f4")
     # convert ROIs to sparse COO 3D-tensor (https://sparse.pydata.org/en/stable/construct.html)
     data = []
@@ -1180,9 +1152,7 @@ def format_caiman_output(
     for i in range(e.A.shape[1]):
         roi = coo_matrix(e.A[:, i].reshape(e.dims, order="F").toarray(), dtype="f4")
         data.append(roi.data)
-        coords.append(
-            np.array([i * np.ones(len(roi.data)), roi.row, roi.col], dtype="i2")
-        )
+        coords.append(np.array([i * np.ones(len(roi.data)), roi.row, roi.col], dtype="i2"))
     if len(data):
         data = np.concatenate(data)
         coords = np.hstack(coords)
@@ -1190,9 +1160,7 @@ def format_caiman_output(
     iscell = np.zeros((e.A.shape[1], 2), dtype="f4")
     iscell[e.idx_components, 0] = 1
     iscell[:, 1] = (
-        e.cnn_preds
-        if (hasattr(e, "cnn_preds") and len(e.cnn_preds) == e.A.shape[1])
-        else np.nan
+        e.cnn_preds if (hasattr(e, "cnn_preds") and len(e.cnn_preds) == e.A.shape[1]) else np.nan
     )
     return traces_corrected, traces_neuropil, traces_roi, data, coords, iscell
 
@@ -1249,9 +1217,7 @@ def save_summary_images_with_rois(
     # Add IDs and save another version
     for i in (0, 1, 2):
         for k in range(rois.shape[0]):
-            ax[i].text(
-                *cm[k], str(k), color="orange" if iscell[k, 0] else "r", fontsize=8 * lw
-            )
+            ax[i].text(*cm[k], str(k), color="orange" if iscell[k, 0] else "r", fontsize=8 * lw)
     plt.savefig(
         output_dir / f"{unique_id}_detected_ROIs_withIDs.png",
         bbox_inches="tight",
@@ -1270,9 +1236,7 @@ def contour_video(
     lower_quantile: float = 0.02,
     upper_quantile: float = 0.9975,
     only_raw: bool = False,
-    n_jobs: int | None = (
-        None if (tmp := os.environ.get("CO_CPUS")) is None else int(tmp)
-    ),
+    n_jobs: int | None = (None if (tmp := os.environ.get("CO_CPUS")) is None else int(tmp)),
     bitrate: str = "0",
     crf: int = 20,
     cpu_used: int = 4,
@@ -1321,9 +1285,7 @@ def contour_video(
     for m in rois:
         if isinstance(m, sparse.COO):
             m = m.todense()
-        ret, thresh = cv2.threshold(
-            (m > m.max() / 10).astype(np.uint8), 0, 1, cv2.THRESH_BINARY
-        )
+        ret, thresh = cv2.threshold((m > m.max() / 10).astype(np.uint8), 0, 1, cv2.THRESH_BINARY)
         contours = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[-2]
         for contour in contours:
             cv2.drawContours(img_contours, contour, -1, rgb, max(max(dims) // 200, 1))
@@ -1333,12 +1295,12 @@ def contour_video(
         mov[:: max(1, len(mov) // 100)], (lower_quantile, upper_quantile)
     )
 
-    def scale(m):
+    def scale(m: np.ndarray) -> np.ndarray:
         return np.array(
             ThreadPool(n_jobs).map(
-                lambda frame: np.clip(
-                    255 * (frame - minmov) / (maxmov - minmov), 0, 255
-                ).astype(np.uint8),
+                lambda frame: np.clip(255 * (frame - minmov) / (maxmov - minmov), 0, 255).astype(
+                    np.uint8
+                ),
                 m,
             )
         )
@@ -1346,9 +1308,7 @@ def contour_video(
     if only_raw:
         mov = scale(mov)
     else:
-        img_contours = np.repeat(img_contours[..., None], 3, 0).reshape(
-            dims[0], 3 * dims[1], -1
-        )
+        img_contours = np.repeat(img_contours[..., None], 3, 0).reshape(dims[0], 3 * dims[1], -1)
         reconstructed = np.tensordot(
             downsample_array(traces.T, downscale, 1, n_jobs=n_jobs).astype("f4"),
             rois,
@@ -1518,9 +1478,7 @@ if __name__ == "__main__":
             data,
             coords,
             iscell,
-        ) = run_caiman_extraction(
-            input_fn, unique_id, args, ops, Ain=None, n_jobs=n_jobs
-        )
+        ) = run_caiman_extraction(input_fn, unique_id, args, ops, Ain=None, n_jobs=n_jobs)
         neuropil_coords, keys = [], []
         input_args = vars(args)
 
@@ -1556,8 +1514,7 @@ if __name__ == "__main__":
                     )
                 )
             logger.info(
-                "'diameter' set to 0 — automatically estimated with Cellpose "
-                f"as {diameter:.0f}."
+                f"'diameter' set to 0 — automatically estimated with Cellpose as {diameter:.0f}."
             )
         settings["diameter"] = [diameter] * 2
         settings["run"]["do_registration"] = False
@@ -1582,9 +1539,7 @@ if __name__ == "__main__":
         # Cellpose segments (see suite2p.detection.anatomical.select_rois).
         settings["detection"].update(
             {
-                "algorithm": args.init
-                if args.init in ("sourcery", "sparsery")
-                else "cellpose",
+                "algorithm": args.init if args.init in ("sourcery", "sparsery") else "cellpose",
                 "denoise": args.denoise,
                 "bin_size": bin_size,
                 "nbins": n_bins,
@@ -1665,13 +1620,10 @@ if __name__ == "__main__":
             try:
                 user_suite2p_params = json.loads(args.suite2p_params)
             except json.JSONDecodeError as e:
-                raise ValueError(
-                    f"Could not parse 'suite2p_params' as JSON: {e}"
-                ) from e
+                raise ValueError(f"Could not parse 'suite2p_params' as JSON: {e}") from e
             if not isinstance(user_suite2p_params, dict):
                 raise ValueError(
-                    "'suite2p_params' must be a JSON object mapping parameter "
-                    "names to values."
+                    "'suite2p_params' must be a JSON object mapping parameter names to values."
                 )
             apply_suite2p_overrides(
                 settings, user_suite2p_params, reserved_suite2p_keys, "suite2p_params"
@@ -1717,9 +1669,7 @@ if __name__ == "__main__":
                     traces_corrected = traces_roi - neucoeff * traces_neuropil
                     r_values = neucoeff * np.ones(traces_roi.shape[0])
                 else:
-                    traces_corrected, r_values, raw_r = get_FC_from_r(
-                        traces_roi, traces_neuropil
-                    )
+                    traces_corrected, r_values, raw_r = get_FC_from_r(traces_roi, traces_neuropil)
                 # convert ROIs to sparse COO 3D-tensor
                 data = []
                 coords = []
@@ -1741,9 +1691,7 @@ if __name__ == "__main__":
                         *dims,
                         lam_percentile=settings["extraction"]["lam_percentile"],
                     ),
-                    inner_neuropil_radius=settings["extraction"][
-                        "inner_neuropil_radius"
-                    ],
+                    inner_neuropil_radius=settings["extraction"]["inner_neuropil_radius"],
                     min_neuropil_pixels=settings["extraction"]["min_neuropil_pixels"],
                     circular=settings["extraction"]["circular_neuropil"],
                 )
@@ -1795,9 +1743,7 @@ if __name__ == "__main__":
                     data,
                     coords,
                     iscell,
-                ) = run_caiman_extraction(
-                    input_fn, unique_id, args, ops, Ain=Ain, n_jobs=n_jobs
-                )
+                ) = run_caiman_extraction(input_fn, unique_id, args, ops, Ain=Ain, n_jobs=n_jobs)
                 neuropil_coords, keys = [], []
 
         else:  # no ROIs found
@@ -1838,9 +1784,7 @@ if __name__ == "__main__":
         shape = np.array([len(traces_roi), *dims], dtype=np.int16)
         f.create_dataset("rois/shape", data=shape)  # neurons x height x width
         if len(neuropil_coords) > 0:
-            f.create_dataset(
-                "rois/neuropil_coords", data=neuropil_coords, compression="gzip"
-            )
+            f.create_dataset("rois/neuropil_coords", data=neuropil_coords, compression="gzip")
         # cellpose
         if cellpose_path:
             with np.load(cellpose_path) as cp:

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -1249,7 +1249,7 @@ def save_summary_images_with_rois(
         bbox_inches="tight",
         pad_inches=0.02,
     )
-    plt.close(fig)
+    plt.close(fix)
 
 
 def contour_video(
@@ -1534,7 +1534,10 @@ if __name__ == "__main__":
         # Overwrite the parameters for suite2p that are exposed
         settings["fs"] = frame_rate
         diameter = args.diameter
-        if diameter == 0 and args.init == "sourcery":
+        if diameter == 0:
+            # Every Suite2p init mode below (cellpose-based or not) needs a
+            # real diameter: Suite2p no longer auto-estimates it internally,
+            # and passing diameter=[0, 0] causes a divide-by-zero downstream.
             with h5py.File(str(motion_corrected_fn), "r") as open_vid:
                 diameter = round(
                     estimate_diameter(

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -1,3 +1,5 @@
+"""Source extraction pipeline using Cellpose, Suite2p, and CaImAn."""
+
 import copy
 import json
 import logging
@@ -286,18 +288,19 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
     @field_validator("init", "neuropil")
     @classmethod
     def lowercase_str_fields(cls, v: str) -> str:
-        """Convert string fields to lowercase"""
+        """Convert string fields to lowercase."""
         return v.lower()
 
     @field_validator("rf")
     @classmethod
     def validate_rf(cls, v: int) -> int | None:
+        """Convert rf=0 to None, meaning process the entire FOV as a single patch."""
         if v == 0:
             return None
         return v
 
     def validate_consistency(self) -> str | None:
-        """Validate command line arguments for consistency"""
+        """Validate command line arguments for consistency."""
         if self.neuropil == "cnmf" and self.init == "corr_pnr":
             # We'll log a warning but still update the parameters
             self.ssub = 1
@@ -317,14 +320,14 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
         return None  # No warning message
 
     def model_post_init(self, _: object) -> None:
-        """Run validation after model initialization"""
+        """Run validation after model initialization."""
         warning = self.validate_consistency()
         if warning:
             logging.warning(warning)
 
 
 def get_metadata(input_dir: Path) -> tuple[dict, dict, dict]:
-    """Get the session and data description metadata from the input directory
+    """Get the session and data description metadata from the input directory.
 
     Parameters
     ----------
@@ -354,8 +357,9 @@ def get_metadata(input_dir: Path) -> tuple[dict, dict, dict]:
 
 
 def get_frame_rate(session: dict) -> float:
-    """Attempt to pull frame rate from session.json
-    Returns none if frame rate not in session.json
+    """Attempt to pull frame rate from session.json.
+
+    Returns none if frame rate not in session.json.
 
     Parameters
     ----------
@@ -380,7 +384,7 @@ def get_frame_rate(session: dict) -> float:
 
 
 def make_output_directory(output_dir: Path, experiment_id: str) -> str:
-    """Creates the output directory if it does not exist
+    """Create the output directory if it does not exist.
 
     Parameters
     ----------
@@ -407,7 +411,7 @@ def write_data_process(
     start_time: dt,
     end_time: dt,
 ) -> None:
-    """Writes output metadata to plane data_process.json
+    """Write output metadata to plane data_process.json.
 
     Parameters
     ----------
@@ -447,7 +451,7 @@ def write_data_process(
 
 
 def write_qc_metrics(output_dir: Path, experiment_id: str, num_rois: int) -> None:
-    """Write the QC metrics to a json file
+    """Write the QC metrics to a json file.
 
     Parameters
     ----------
@@ -458,7 +462,6 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, num_rois: int) -> Non
     num_rois: int
         number of ROIs detected in this plane
     """
-
     # Build options and statuses
     options = []
     statuses = []
@@ -487,7 +490,7 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, num_rois: int) -> Non
 def create_virtual_dataset(
     h5_file: Path, frame_locations: list, frames_length: int, temp_dir: Path
 ) -> Path:
-    """Creates a virtual dataset from a list of frame locations
+    """Create a virtual dataset from a list of frame locations.
 
     Parameters
     ----------
@@ -522,7 +525,7 @@ def create_virtual_dataset(
 
 
 def bergamo_segmentation(motion_corr_fp: Path, session: dict, temp_dir: Path) -> Path:
-    """Creates a virtual dataset for Bergamo segmentation by filtering out photostimulation frames
+    """Create a virtual dataset for Bergamo segmentation by filtering out photostimulation frames.
 
     Parameters
     ----------
@@ -532,6 +535,7 @@ def bergamo_segmentation(motion_corr_fp: Path, session: dict, temp_dir: Path) ->
         session information
     temp_dir: Path
         temporary directory for virtual dataset
+
     Returns
     -------
     h5_file: Path
@@ -653,7 +657,7 @@ def create_mmap_file(
 
 # ROI Analysis Functions
 def com(rois: np.ndarray | sparse.COO) -> np.ndarray:
-    """Calculation of the center of mass for spatial components
+    """Calculate the center of mass for spatial components.
 
     Parameters
     ----------
@@ -676,7 +680,7 @@ def com(rois: np.ndarray | sparse.COO) -> np.ndarray:
 def get_contours(
     rois: np.ndarray | sparse.COO, thr: float = 0.2, thr_method: str = "max"
 ) -> list[dict]:
-    """Gets contour of spatial components and returns their coordinates
+    """Get contour of spatial components and return their coordinates.
 
     Parameters
     ----------
@@ -694,7 +698,6 @@ def get_contours(
     coordinates : list
         list of coordinates with center of mass and contour plot coordinates for each component
     """
-
     nr, dims = rois.shape[0], rois.shape[1:]
     d1, d2 = dims[:2]
     d = np.prod(dims)
@@ -852,8 +855,7 @@ def get_r_from_min_mi(
     resolution: float = 0.01,
     r_test_range: list[float] = [0, 2],
 ) -> tuple[float, np.ndarray, np.ndarray]:
-    """Get the r value that minimizes the mutual information between
-    the corrected trace and the neuropil trace.
+    """Get the r value minimizing mutual information between the corrected and neuropil traces.
 
     Parameters
     ----------
@@ -1175,7 +1177,7 @@ def save_summary_images_with_rois(
     ops: dict,
     corr_img: np.ndarray,
 ) -> None:
-    """Save summary images with ROI contours
+    """Save summary images with ROI contours.
 
     Parameters
     ----------
@@ -1242,7 +1244,7 @@ def contour_video(
     crf: int = 20,
     cpu_used: int = 4,
 ) -> None:
-    """Create a video contours using vp9 codec via imageio-ffmpeg
+    """Create a video contours using vp9 codec via imageio-ffmpeg.
 
     Parameters
     ----------

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -929,8 +929,12 @@ def get_FC_from_r(
     raw_r : np.ndarray
         1D array of r values that minimized the mutual information before thresholding.
     """
-    r_values = np.array([get_r_from_min_mi(raw_trace[i], neuropil_trace[i])[0]
-                         for i in range(raw_trace.shape[0])])
+    r_values = np.array(
+        [
+            get_r_from_min_mi(raw_trace[i], neuropil_trace[i])[0]
+            for i in range(raw_trace.shape[0])
+        ]
+    )
     mean_r = np.mean(r_values[r_values < 1])
     if np.sum(r_values < 1) < min_r_count:
         mean_r = 0.8
@@ -1578,7 +1582,9 @@ if __name__ == "__main__":
         # Cellpose segments (see suite2p.detection.anatomical.select_rois).
         settings["detection"].update(
             {
-                "algorithm": args.init if args.init in ("sourcery", "sparsery") else "cellpose",
+                "algorithm": args.init
+                if args.init in ("sourcery", "sparsery")
+                else "cellpose",
                 "denoise": args.denoise,
                 "bin_size": bin_size,
                 "nbins": nbinned,
@@ -1735,7 +1741,9 @@ if __name__ == "__main__":
                         *dims,
                         lam_percentile=settings["extraction"]["lam_percentile"],
                     ),
-                    inner_neuropil_radius=settings["extraction"]["inner_neuropil_radius"],
+                    inner_neuropil_radius=settings["extraction"][
+                        "inner_neuropil_radius"
+                    ],
                     min_neuropil_pixels=settings["extraction"]["min_neuropil_pixels"],
                     circular=settings["extraction"]["circular_neuropil"],
                 )

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -6,7 +6,6 @@ import sys
 from datetime import datetime as dt
 from multiprocessing.pool import Pool, ThreadPool
 from pathlib import Path
-from typing import Optional, Tuple, Union
 
 import caiman
 import cv2
@@ -22,14 +21,18 @@ from aind_data_schema.core.quality_control import QCMetric, QCStatus, Status
 from aind_log_utils.log import setup_logging
 from aind_ophys_utils.array_utils import downsample_array
 from aind_ophys_utils.segmentation_utils import roi_probabilities
-from aind_ophys_utils.summary_images import (max_corr_image, max_image,
-                                             mean_image)
-from aind_qcportal_schema.metric_value import CheckboxMetric, CurationMetric
+from aind_ophys_utils.summary_images import (
+    max_corr_image,
+    max_image,
+    mean_image,
+)
+from aind_qcportal_schema.metric_value import CheckboxMetric
 from caiman.source_extraction.cnmf import cnmf, params
 from cellpose.models import Cellpose
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from scipy.sparse import coo_matrix, hstack, linalg
+from suite2p.parameters import set_settings_orig
 
 
 class ExtractionSettings(BaseSettings, cli_parse_args=True):
@@ -63,7 +66,6 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
             "Initialization method for finding masks. Options: "
             "max/mean: Cellpose on max projection image divided by mean image; "
             "mean: Cellpose on mean image; "
-            "enhanced_mean: Cellpose on enhanced mean image; "
             "max: Cellpose on maximum projection image; "
             "sourcery: Suite2p's functional mode without 'sparse_mode'; "
             "sparsery: Suite2p's functional mode with 'sparse_mode'; "
@@ -152,7 +154,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
             "Number of background components if using CaImAn with neuropil=cnmf."
         ),
     )
-    rf: Optional[int] = Field(
+    rf: int | None = Field(
         default=40,
         description=(
             "Half-size of patches in pixels for CaImAn processing. If 0, the entire FOV "
@@ -254,7 +256,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
         description=(
             "Serialized JSON string of Suite2p parameters to override defaults. "
             "Only applied when running a Suite2p-based init mode "
-            "(max/mean, mean, enhanced_mean, max, sourcery, sparsery). "
+            "(max/mean, mean, max, sourcery, sparsery). "
             "Pipeline-controlled keys (input/output paths, fs, nbinned, "
             "do_registration, roidetect, spikedetect, neuropil_extract, "
             "bin_duration, and any key already exposed as a CLI flag) are "
@@ -262,7 +264,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
             "Applied AFTER --suite2p-ops, so it wins on key collisions."
         ),
     )
-    suite2p_ops: Optional[Path] = Field(
+    suite2p_ops: Path | None = Field(
         default=None,
         description=(
             "Path to a Suite2p ops.npy file to load parameters from. "
@@ -286,12 +288,12 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
 
     @field_validator("rf")
     @classmethod
-    def validate_rf(cls, v: int) -> Optional[int]:
+    def validate_rf(cls, v: int) -> int | None:
         if v == 0:
             return None
         return v
 
-    def validate_consistency(self) -> Optional[str]:
+    def validate_consistency(self) -> str | None:
         """Validate command line arguments for consistency"""
         if self.neuropil == "cnmf" and self.init == "corr_pnr":
             # We'll log a warning but still update the parameters
@@ -311,10 +313,6 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
                 "Can't use Suite2p neuropil model with 'greedy_roi' or 'corr_pnr' initialization"
             )
 
-        # For backward compatibility
-        if self.init in ("1", "2", "3", "4"):
-            self.init = ("max/mean", "mean", "enhanced_mean", "max")[int(self.init) - 1]
-
         return None  # No warning message
 
     def model_post_init(self, _) -> None:
@@ -324,7 +322,7 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
             logging.warning(warning)
 
 
-def get_metadata(input_dir: Path) -> Tuple[dict, dict, dict]:
+def get_metadata(input_dir: Path) -> tuple[dict, dict, dict]:
     """Get the session and data description metadata from the input directory
 
     Parameters
@@ -402,8 +400,8 @@ def make_output_directory(output_dir: Path, experiment_id: str) -> str:
 
 def write_data_process(
     metadata: dict,
-    input_fp: Union[str, Path],
-    output_fp: Union[str, Path],
+    input_fp: str | Path,
+    output_fp: str | Path,
     unique_id: str,
     start_time: dt,
     end_time: dt,
@@ -661,7 +659,7 @@ def create_mmap_file(
 
 
 # ROI Analysis Functions
-def com(rois: Union[np.ndarray, sparse.COO]) -> np.ndarray:
+def com(rois: np.ndarray | sparse.COO) -> np.ndarray:
     """Calculation of the center of mass for spatial components
 
     Parameters
@@ -679,11 +677,11 @@ def com(rois: Union[np.ndarray, sparse.COO]) -> np.ndarray:
         list(map(np.ravel, np.meshgrid(np.arange(d2), np.arange(d1)))), dtype=rois.dtype
     )
     A = rois.reshape((rois.shape[0], d1 * d2)).tocsc()
-    return (A / A.sum(axis=1)).dot(Coor.T)
+    return (A / A.sum(axis=1).reshape(-1, 1)).dot(Coor.T)
 
 
 def get_contours(
-    rois: Union[np.ndarray, sparse.COO], thr: float = 0.2, thr_method: str = "max"
+    rois: np.ndarray | sparse.COO, thr: float = 0.2, thr_method: str = "max"
 ) -> list[dict]:
     """Gets contour of spatial components and returns their coordinates
 
@@ -869,17 +867,14 @@ def get_FC_from_r(
     raw_r : np.ndarray
         1D array of r values that minimized the mutual information before thresholding.
     """
-    r_values = np.zeros(raw_trace.shape[0])
-    FCs = np.zeros_like(raw_trace)
-    for roi in range(raw_trace.shape[0]):
-        r_values[roi], _, _ = get_r_from_min_mi(raw_trace[roi], neuropil_trace[roi])
+    r_values = np.array([get_r_from_min_mi(raw_trace[i], neuropil_trace[i])[0]
+                         for i in range(raw_trace.shape[0])])
     mean_r = np.mean(r_values[r_values < 1])
-    if len(np.where(r_values < 1)[0]) < min_r_count:
+    if np.sum(r_values < 1) < min_r_count:
         mean_r = 0.8
     raw_r = r_values.copy()
     r_values[r_values >= 1] = mean_r
-    for roi in range(raw_trace.shape[0]):
-        FCs[roi] = raw_trace[roi] - r_values[roi] * neuropil_trace[roi]
+    FCs = raw_trace - r_values[:, None] * neuropil_trace
     return FCs, r_values, raw_r
 
 
@@ -888,8 +883,8 @@ def build_CNMFParams(
     args: ExtractionSettings,
     ops: dict,
     cnmfe: bool,
-    Ain: Optional[np.ndarray] = None,
-    dims: Optional[tuple] = None,
+    Ain: np.ndarray | None = None,
+    dims: tuple | None = None,
 ) -> params.CNMFParams:
     """Build parameter dictionary for CaImAn extraction.
 
@@ -970,13 +965,13 @@ def build_CNMFParams(
 
 
 def run_caiman_extraction(
-    input_fn: Union[str, Path],
+    input_fn: str | Path,
     unique_id: str,
     args: ExtractionSettings,
     ops: dict,
-    Ain: Optional[np.ndarray] = None,
-    n_jobs: Optional[int] = None,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    Ain: np.ndarray | None = None,
+    n_jobs: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Run CaImAn to extract neural activity traces.
 
     Parameters
@@ -998,8 +993,18 @@ def run_caiman_extraction(
 
     Returns
     -------
-    tuple
-        Tuple containing (traces_corrected, traces_neuropil, traces_roi, data, coords, iscell)
+    traces_corrected : np.ndarray
+        Corrected fluorescence traces (ROIs x time).
+    traces_neuropil : np.ndarray
+        Neuropil traces (ROIs x time).
+    traces_roi : np.ndarray
+        Raw fluorescence traces including neuropil (ROIs x time).
+    data : np.ndarray
+        Values for ROI spatial footprints in sparse format.
+    coords : np.ndarray
+        Coordinates for ROI spatial footprints in sparse format (3 x N).
+    iscell : np.ndarray
+        Array indicating for each component whether it is a cell (1) or not (0).
     """
     logger.info(f"running CaImAn v{caiman.__version__}")
     # Determine if using CNMF-E
@@ -1027,7 +1032,7 @@ def run_caiman_extraction(
             cnm = cnm.refit(movie, dview=pool)
         # Make sure dims are set and gSig is integer for component evaluation
         cnm.estimates.dims = dims
-        cnm.params.init["gSig"] = tuple(map(int, cnm.params.init["gSig"]))
+        cnm.params.init["gSig"] = tuple(np.round(cnm.params.init["gSig"]).astype(int))
         # Evaluate components
         cnm.estimates.evaluate_components(movie, cnm.params, dview=pool)
     # Return formatted output
@@ -1036,7 +1041,7 @@ def run_caiman_extraction(
 
 def format_caiman_output(
     e: caiman.source_extraction.cnmf.estimates.Estimates, cnmfe: bool, Yr: np.ndarray
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Format the output from CaImAn's CNMF for standardized extraction results.
 
     Parameters
@@ -1051,19 +1056,20 @@ def format_caiman_output(
     Returns
     -------
     traces_corrected : np.ndarray
-        Array of corrected fluorescence traces (ROIs x time)
+        Array of corrected fluorescence traces (ROIs x time).
     traces_neuropil : np.ndarray
-        Array of neuropil traces (ROIs x time)
+        Array of neuropil traces (ROIs x time).
     traces_roi : np.ndarray
-        Array of raw fluorescence traces including neuropil (ROIs x time)
+        Array of raw fluorescence traces including neuropil (ROIs x time).
     data : np.ndarray
-        Values for ROI spatial footprints in sparse format
+        Values for ROI spatial footprints in sparse format.
     coords : np.ndarray
-        Coordinates for ROI spatial footprints in sparse format (3 x N)
+        Coordinates for ROI spatial footprints in sparse format (3 x N).
     iscell : np.ndarray
-        Array indicating for each component (ROI) whether it's a cell (1) or not (0)
+        Array indicating for each component (ROI) whether it's a cell (1) or not (0).
     """
-    assert np.allclose(linalg.norm(e.A, 2, 0), 1)
+    if not np.allclose(linalg.norm(e.A, 2, 0), 1):
+        e.normalize_components()
     traces_corrected = (e.C + e.YrA).astype("f4")
     if cnmfe:
         Atb0 = e.A.T.dot(e.b0)[:, None]
@@ -1111,7 +1117,11 @@ def format_caiman_output(
     # maybe TODO: save background
     iscell = np.zeros((e.A.shape[1], 2), dtype="f4")
     iscell[e.idx_components, 0] = 1
-    iscell[:, 1] = e.cnn_preds if hasattr(e, "cnn_preds") else np.nan
+    iscell[:, 1] = (
+        e.cnn_preds
+        if (hasattr(e, "cnn_preds") and len(e.cnn_preds) == e.A.shape[1])
+        else np.nan
+    )
     return traces_corrected, traces_neuropil, traces_roi, data, coords, iscell
 
 
@@ -1137,7 +1147,7 @@ def save_summary_images_with_rois(
     iscell : np.ndarray
         Array of shape (K, 2) indicating whether each component is a cell
     ops : dict
-        Dictionary containing summary images
+        Dictionary containing summary images (keys: ``'meanImg'``, ``'max_proj'``)
     corr_img : np.ndarray
         Correlation image
     """
@@ -1175,19 +1185,20 @@ def save_summary_images_with_rois(
         bbox_inches="tight",
         pad_inches=0.02,
     )
+    plt.close(fig)
 
 
 def contour_video(
     output_path: str,
-    data: Union[h5py.Dataset, np.ndarray],
-    rois: Union[sparse.COO, np.ndarray],
+    data: h5py.Dataset | np.ndarray,
+    rois: sparse.COO | np.ndarray,
     traces: np.ndarray,
     downscale: int = 10,
     fs: float = 30,
     lower_quantile: float = 0.02,
     upper_quantile: float = 0.9975,
     only_raw: bool = False,
-    n_jobs: Optional[int] = (
+    n_jobs: int | None = (
         None if (tmp := os.environ.get("CO_CPUS")) is None else int(tmp)
     ),
     bitrate: str = "0",
@@ -1206,14 +1217,14 @@ def contour_video(
         Tensor of spatial components (K x height x width)
     traces: np.ndarray
         Tensor of temporal components (K x T)
-    downscale : int = 10
-        Decimation factor
-    fs : float
-        Desired frame rate for encoded video
-    lower_quantile : float
-        Lower cutoff value supplied to `np.quantile()` for normalization
-    upper_quantile : float
-        Upper cutoff value supplied to `np.quantile()` for normalization
+    downscale : int, optional
+        Decimation factor, by default 10
+    fs : float, optional
+        Desired frame rate for encoded video, by default 30
+    lower_quantile : float, optional
+        Lower cutoff value supplied to `np.quantile()` for normalization, by default 0.02
+    upper_quantile : float, optional
+        Upper cutoff value supplied to `np.quantile()` for normalization, by default 0.9975
     only_raw : bool, optional
         Produce video of raw data only, i.e. no reconstruction and residual
     n_jobs : int, optional
@@ -1335,6 +1346,47 @@ def contour_video(
     writer.close()
 
 
+def apply_suite2p_overrides(
+    settings: dict, overrides: dict, reserved_keys: set, source_label: str
+) -> None:
+    """Merge user-supplied Suite2p parameter overrides into ``settings`` in place.
+
+    Reserved (pipeline-controlled) keys are dropped. Remaining keys are matched
+    against ``settings`` at any nesting depth via ``set_settings_orig``, which
+    supports flattened key names from the pre-1.0 Suite2p API.
+
+    Parameters
+    ----------
+    settings : dict
+        Suite2p settings dictionary (as returned by ``suite2p.default_settings()``),
+        updated in place.
+    overrides : dict
+        User-supplied parameter overrides (flat dict).
+    reserved_keys : set
+        Keys that are pipeline-controlled and must not be overridden.
+    source_label : str
+        Human-readable description of where ``overrides`` came from, used in
+        logging.
+    """
+    overrides = copy.deepcopy(overrides)
+    reserved_present = sorted(set(overrides) & reserved_keys)
+    for k in reserved_present:
+        del overrides[k]
+    remaining = dict(overrides)
+    set_settings_orig(settings, remaining)
+    applied = sorted(set(overrides) - set(remaining))
+    logging.warning(
+        f"Applied {len(applied)} Suite2p parameter(s) from '{source_label}': "
+        f"{applied}. Dropped {len(reserved_present)} reserved key(s): "
+        f"{reserved_present}."
+        + (
+            f" Ignored {len(remaining)} unrecognized key(s): {sorted(remaining)}."
+            if remaining
+            else ""
+        )
+    )
+
+
 if __name__ == "__main__":
     start_time = dt.now()
     # Parse command-line arguments
@@ -1403,117 +1455,126 @@ if __name__ == "__main__":
     else:
         # Run Cellpose via Suite2p to get ROI seeds
         # =========================================
-        # Set suite2p args.
-        suite2p_args = suite2p.default_ops()
+        with h5py.File(str(motion_corrected_fn), "r") as f:
+            nframes = f["data"].shape[0]
+
+        # Set suite2p db (paths) and settings (everything else).
+        db = suite2p.default_db()
+        db["input_format"] = "h5"
+        db["data_path"] = [motion_corrected_fn.parent]
+        db["file_list"] = [str(motion_corrected_fn)]
+        db["save_path0"] = str(tmp_dir)
+        db["functional_chan"] = args.functional_chan
+
+        settings = suite2p.default_settings()
         # Overwrite the parameters for suite2p that are exposed
-        suite2p_args["diameter"] = args.diameter
-        if args.diameter == 0 and args.init == "sourcery":
+        settings["fs"] = frame_rate
+        diameter = args.diameter
+        if diameter == 0 and args.init == "sourcery":
             with h5py.File(str(motion_corrected_fn), "r") as open_vid:
-                suite2p_args["diameter"] = round(
-                    Cellpose().sz.eval(mean_image(open_vid["data"]))[0]
-                )
+                diameter = round(Cellpose().sz.eval(mean_image(open_vid["data"]))[0])
             logger.info(
                 "'diameter' set to 0 — automatically estimated with Cellpose "
-                f"as {suite2p_args['diameter']:.0f}."
+                f"as {diameter:.0f}."
             )
-        suite2p_args["anatomical_only"] = {
-            "max/mean": 1,
-            "mean": 2,
-            "enhanced_mean": 3,
-            "max": 4,
-        }.get(args.init, 0)
-        suite2p_args["cellprob_threshold"] = args.cellprob_threshold
-        suite2p_args["flow_threshold"] = args.flow_threshold
-        suite2p_args["spatial_hp_cp"] = args.spatial_hp_cp
-        suite2p_args["pretrained_model"] = args.pretrained_model
-        suite2p_args["denoise"] = args.denoise
-        suite2p_args["save_path0"] = str(tmp_dir)
-        suite2p_args["functional_chan"] = args.functional_chan
-        suite2p_args["threshold_scaling"] = args.threshold_scaling
-        suite2p_args["max_overlap"] = args.max_overlap
-        suite2p_args["soma_crop"] = args.soma_crop
-        suite2p_args["allow_overlap"] = args.allow_overlap
-        # Here we overwrite the parameters for suite2p that will not change in our
-        # processing pipeline. These are parameters that are not exposed to
-        # minimize code length. Those are not set to default.
-        suite2p_args["sparse_mode"] = args.init == "sparsery"
-        suite2p_args["h5py"] = str(motion_corrected_fn)
-        suite2p_args["data_path"] = []
-        suite2p_args["roidetect"] = True
-        suite2p_args["do_registration"] = 0
-        suite2p_args["spikedetect"] = False
-        suite2p_args["fs"] = frame_rate
-        suite2p_args["neuropil_extract"] = True
-        # determine nbinned from bin_duration and fs
-        # The duration of time (in seconds) that
-        suite2p_args["bin_duration"] = 3.7
-        # should be considered 1 bin for Suite2P ROI detection purposes. Requires
-        # a valid value for 'fs' in order to derive an
-        # nbinned Suite2P value. This allows consistent temporal downsampling
-        # across movies with different lengths and/or frame rates.
-        with h5py.File(suite2p_args["h5py"], "r") as f:
-            nframes = f["data"].shape[0]
-        bin_size = suite2p_args["bin_duration"] * suite2p_args["fs"]
-        suite2p_args["nbinned"] = int(nframes / bin_size)
+        settings["diameter"] = [diameter] * 2
+        settings["run"]["do_registration"] = False
+        settings["run"]["do_deconvolution"] = False
+        # determine bin_size/nbins from bin_duration and fs
+        # The duration of time (in seconds) that should be considered 1 bin
+        # for Suite2P ROI detection purposes. This allows consistent temporal
+        # downsampling across movies with different lengths and/or frame rates.
+        bin_duration = 3.7
+        bin_size = round(bin_duration * frame_rate)
+        nbinned = int(nframes / bin_size)
         logger.info(
             f"Movie has {nframes} frames collected at "
-            f"{suite2p_args['fs']} Hz. "
+            f"{frame_rate} Hz. "
             "To get a bin duration of "
-            f"{suite2p_args['bin_duration']} "
-            f"seconds, setting nbinned to "
-            f"{suite2p_args['nbinned']}."
+            f"{bin_duration} "
+            f"seconds, setting nbins to "
+            f"{nbinned}."
+        )
+        # "sourcery"/"sparsery" select suite2p's own functional detection;
+        # any other init mode runs Cellpose, with "img" picking which image
+        # Cellpose segments (see suite2p.detection.anatomical.select_rois).
+        settings["detection"].update(
+            {
+                "algorithm": args.init if args.init in ("sourcery", "sparsery") else "cellpose",
+                "denoise": args.denoise,
+                "bin_size": bin_size,
+                "nbins": nbinned,
+                "threshold_scaling": args.threshold_scaling,
+                "max_overlap": args.max_overlap,
+                "soma_crop": args.soma_crop,
+            }
+        )
+        settings["detection"]["cellpose_settings"].update(
+            {
+                "cellpose_model": args.pretrained_model,
+                "img": {
+                    "max/mean": "max_proj / meanImg",
+                    "mean": "meanImg",
+                    "max": "max_proj",
+                }.get(args.init, "max_proj"),
+                "highpass_spatial": args.spatial_hp_cp,
+                "flow_threshold": args.flow_threshold,
+                "cellprob_threshold": args.cellprob_threshold,
+            }
+        )
+        settings["extraction"].update(
+            {
+                "allow_overlap": args.allow_overlap,
+                "neuropil_extract": True,
+            }
         )
 
         # Keys this script controls — must not be overridden by user-supplied ops.
-        # Includes pipeline-fixed plumbing (paths, fs, nbinned, ...) and every
+        # Includes pipeline-fixed plumbing (paths, fs, nbins, ...) and every
         # parameter already exposed as a CLI flag (so the CLI value wins).
         reserved_suite2p_keys = {
-            "anatomical_only",
+            "algorithm",
             "allow_overlap",
-            "bin_duration",
+            "bin_size",
+            "cellpose_model",
             "cellprob_threshold",
             "data_path",
             "denoise",
             "diameter",
+            "do_deconvolution",
+            "do_detection",
             "do_registration",
+            "file_list",
             "flow_threshold",
-            "fs",
             "functional_chan",
-            "h5py",
+            "fs",
+            "highpass_spatial",
+            "img",
+            "input_format",
             "max_overlap",
-            "nbinned",
+            "nbins",
             "neuropil_extract",
-            "pretrained_model",
-            "roidetect",
             "save_path0",
             "soma_crop",
-            "sparse_mode",
-            "spatial_hp_cp",
-            "spikedetect",
             "threshold_scaling",
         }
 
         if args.suite2p_ops is not None:
-            ops_path = args.suite2p_ops
-            if not ops_path.is_file():
-                raise ValueError(f"'suite2p_ops' file not found: {ops_path}")
-            loaded = np.load(ops_path, allow_pickle=True)
+            suite2p_ops_path = args.suite2p_ops
+            if not suite2p_ops_path.is_file():
+                raise ValueError(f"'suite2p_ops' file not found: {suite2p_ops_path}")
+            loaded = np.load(suite2p_ops_path, allow_pickle=True)
             # ops.npy is typically a 0-d object array wrapping a dict
             ops_dict = loaded[()] if isinstance(loaded, np.ndarray) else loaded
             if not isinstance(ops_dict, dict):
                 raise ValueError(
                     f"'suite2p_ops' did not contain a dict (got {type(ops_dict).__name__})"
                 )
-            applied = {
-                k: v for k, v in ops_dict.items() if k not in reserved_suite2p_keys
-            }
-            dropped = sorted(set(ops_dict) - set(applied))
-            for k, v in applied.items():
-                suite2p_args[k] = copy.deepcopy(v)
-            logger.warning(
-                f"Loaded {len(applied)} Suite2p parameter(s) from "
-                f"'suite2p_ops' ({ops_path}). Applied: {sorted(applied)}. "
-                f"Dropped {len(dropped)} reserved key(s): {dropped}"
+            apply_suite2p_overrides(
+                settings,
+                ops_dict,
+                reserved_suite2p_keys,
+                f"suite2p_ops ({suite2p_ops_path})",
             )
 
         if args.suite2p_params:
@@ -1528,25 +1589,15 @@ if __name__ == "__main__":
                     "'suite2p_params' must be a JSON object mapping parameter "
                     "names to values."
                 )
-            applied_params = {
-                k: v
-                for k, v in user_suite2p_params.items()
-                if k not in reserved_suite2p_keys
-            }
-            dropped_params = sorted(set(user_suite2p_params) - set(applied_params))
-            for k, v in applied_params.items():
-                suite2p_args[k] = copy.deepcopy(v)
-            logger.warning(
-                f"Overriding {len(applied_params)} Suite2p parameter(s) from "
-                f"'suite2p_params': {sorted(applied_params)}. "
-                f"Dropped {len(dropped_params)} reserved key(s): {dropped_params}"
+            apply_suite2p_overrides(
+                settings, user_suite2p_params, reserved_suite2p_keys, "suite2p_params"
             )
 
         logger.info(f"running Suite2P v{suite2p.version}")
         try:
-            input_args = {**vars(args), **suite2p_args}
-            suite2p.run_s2p(suite2p_args)
-        except IndexError:  # raised when no ROIs found
+            input_args = {**vars(args), **db, **settings}
+            suite2p.run_s2p(db, settings)
+        except ValueError:  # raised when no ROIs found
             pass
 
         # load in the rois from the stat file and movie path for shape
@@ -1567,7 +1618,7 @@ if __name__ == "__main__":
                         _,
                         _,
                     ) = suite2p.extraction.extraction_wrapper(
-                        suite2p_stats, h5py.File(input_fn)["data"], ops=suite2p_args
+                        suite2p_stats, h5py.File(input_fn)["data"], ops=settings
                     )
                 else:  # all frames have already been used for detection as well as extraction
                     suite2p_f_path = str(next(tmp_dir.rglob("F.npy")))
@@ -1576,10 +1627,9 @@ if __name__ == "__main__":
                     traces_neuropil = np.load(suite2p_fneu_path, allow_pickle=True)
                 iscell = np.load(str(next(tmp_dir.rglob("iscell.npy"))))
                 if args.neuropil == "suite2p":
-                    traces_corrected = (
-                        traces_roi - suite2p_args["neucoeff"] * traces_neuropil
-                    )
-                    r_values = suite2p_args["neucoeff"] * np.ones(traces_roi.shape[0])
+                    neucoeff = settings["extraction"]["neuropil_coefficient"]
+                    traces_corrected = traces_roi - neucoeff * traces_neuropil
+                    r_values = neucoeff * np.ones(traces_roi.shape[0])
                 else:
                     traces_corrected, r_values, raw_r = get_FC_from_r(
                         traces_roi, traces_neuropil
@@ -1587,7 +1637,6 @@ if __name__ == "__main__":
                 # convert ROIs to sparse COO 3D-tensor
                 data = []
                 coords = []
-                neuropil_coords = []
                 for i, roi in enumerate(suite2p_stats):
                     data.append(roi["lam"])
                     coords.append(
@@ -1596,25 +1645,37 @@ if __name__ == "__main__":
                             dtype=np.int16,
                         )
                     )
-                    neuropil_coords.append(
+                # Suite2p no longer exposes a per-ROI neuropil mask in stat.npy;
+                # recompute it with the same settings used during extraction.
+                neuropil_masks = suite2p.extraction.create_neuropil_masks(
+                    ypixs=[roi["ypix"] for roi in suite2p_stats],
+                    xpixs=[roi["xpix"] for roi in suite2p_stats],
+                    cell_pix=suite2p.extraction.create_cell_pix(
+                        suite2p_stats,
+                        *dims,
+                        lam_percentile=settings["extraction"]["lam_percentile"],
+                    ),
+                    inner_neuropil_radius=settings["extraction"]["inner_neuropil_radius"],
+                    min_neuropil_pixels=settings["extraction"]["min_neuropil_pixels"],
+                    circular=settings["extraction"]["circular_neuropil"],
+                )
+                neuropil_coords = np.hstack(
+                    [
                         np.array(
-                            [
-                                i * np.ones(len(roi["neuropil_mask"])),
-                                roi["neuropil_mask"] // dims[1],
-                                roi["neuropil_mask"] % dims[1],
-                            ],
+                            [i * np.ones(len(npix)), npix // dims[1], npix % dims[1]],
                             dtype=np.int16,
                         )
-                    )
+                        for i, npix in enumerate(neuropil_masks)
+                    ]
+                )
                 keys = list(suite2p_stats[0].keys())
-                for k in ("ypix", "xpix", "lam", "neuropil_mask"):
+                for k in ("ypix", "xpix", "lam"):
                     keys.remove(k)
                 stat = {}
                 for k in keys:
                     stat[k] = [s[k] for s in suite2p_stats]
                 data = np.concatenate(data)
                 coords = np.hstack(coords)
-                neuropil_coords = np.hstack(neuropil_coords)
                 stat["soma_crop"] = np.concatenate(stat["soma_crop"])
                 stat["overlap"] = np.concatenate(stat["overlap"])
 
@@ -1630,7 +1691,15 @@ if __name__ == "__main__":
                     ]
                 )
                 ops_path = str(next(tmp_dir.rglob("ops.npy"), ""))
-                ops = np.load(ops_path, allow_pickle=True)[()]
+                ops = np.load(ops_path, allow_pickle=True)[()] if ops_path else {}
+                if ops.get("max_proj") is None:
+                    # Registration is skipped in this pipeline, so suite2p's own
+                    # ops.npy doesn't carry summary images; compute them directly.
+                    with h5py.File(str(motion_corrected_fn), "r") as open_vid:
+                        ops = {
+                            "meanImg": mean_image(open_vid["data"]),
+                            "max_proj": max_image(open_vid["data"]),
+                        }
                 (
                     traces_corrected,
                     traces_neuropil,
@@ -1711,6 +1780,14 @@ if __name__ == "__main__":
         # summary images
         if ops_path:
             ops = np.load(ops_path, allow_pickle=True)[()]
+        if "ops" not in locals() or ops.get("max_proj") is None:
+            # Registration is skipped in this pipeline, so suite2p's own
+            # ops.npy doesn't carry summary images; compute them directly.
+            with h5py.File(str(motion_corrected_fn), "r") as open_vid:
+                ops = {
+                    "meanImg": mean_image(open_vid["data"]),
+                    "max_proj": max_image(open_vid["data"]),
+                }
         f.create_dataset("meanImg", data=ops["meanImg"], compression="gzip")
         f.create_dataset("maxImg", data=ops["max_proj"], compression="gzip")
 

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -139,11 +139,11 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
         ),
     )
     # CNMF parameters
-    K: int = Field(
-        default=5,
+    nr: int = Field(
+        default=30,
         description=(
-            "Maximum number of components to be found per patch when using greedy_roi "
-            "or corr_pnr initialization in CaImAn."
+            "Maximum number of components to be found when using greedy_roi or corr_pnr "
+            "(per patch or whole FOV depending on whether rf=None)."
         ),
     )
     nb: int = Field(
@@ -936,7 +936,7 @@ def build_CNMFParams(
         # For initial ROI detection (greedy_roi or corr_pnr)
         params_dict.update(
             {
-                "K": args.K,
+                "K": args.nr,
                 "method_init": args.init,
                 "rf": args.rf,
                 "stride": args.stride,

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -261,9 +261,9 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
             "Serialized JSON string of Suite2p parameters to override defaults. "
             "Only applied when running a Suite2p-based init mode "
             "(max/mean, mean, max, sourcery, sparsery). "
-            "Pipeline-controlled keys (input/output paths, fs, nbinned, "
-            "do_registration, roidetect, spikedetect, neuropil_extract, "
-            "bin_duration, and any key already exposed as a CLI flag) are "
+            "Pipeline-controlled keys (input/output paths, fs, nbins, bin_size, "
+            "do_registration, do_detection, do_deconvolution, neuropil_extract, "
+            "and any key already exposed as a CLI flag) are "
             "stripped before merging; dropped keys are logged. "
             "Applied AFTER --suite2p-ops, so it wins on key collisions."
         ),
@@ -1568,14 +1568,14 @@ if __name__ == "__main__":
         # downsampling across movies with different lengths and/or frame rates.
         bin_duration = 3.7
         bin_size = max(1, round(bin_duration * frame_rate))
-        nbinned = max(1, int(nframes / bin_size))
+        n_bins = max(1, int(nframes / bin_size))
         logger.info(
             f"Movie has {nframes} frames collected at "
             f"{frame_rate} Hz. "
             "To get a bin duration of "
             f"{bin_duration} "
             f"seconds, setting nbins to "
-            f"{nbinned}."
+            f"{n_bins}."
         )
         # "sourcery"/"sparsery" select suite2p's own functional detection;
         # any other init mode runs Cellpose, with "img" picking which image
@@ -1587,7 +1587,7 @@ if __name__ == "__main__":
                 else "cellpose",
                 "denoise": args.denoise,
                 "bin_size": bin_size,
-                "nbins": nbinned,
+                "nbins": n_bins,
                 "threshold_scaling": args.threshold_scaling,
                 "max_overlap": args.max_overlap,
                 "soma_crop": args.soma_crop,

--- a/code/extraction.py
+++ b/code/extraction.py
@@ -123,8 +123,12 @@ class ExtractionSettings(BaseSettings, cli_parse_args=True):
     pretrained_model: str = Field(
         default="cpsam_v2",
         description=(
-            "CellPose pretrained model to use. Common options: 'cpsam_v2' or 'cpsam' "
-            "(Cellpose-SAM foundation models), or path to a custom model file."
+            "CellPose pretrained model to use. Built-in options: "
+            "'cpsam_v2' (Cellpose-SAM, includes a fix for low-contrast regions), "
+            "'cpsam' (original Cellpose-SAM model), "
+            "'cpdino' (Cellpose-DINO, DINOv3-ViTL backbone), "
+            "'cpdino-vitb' (Cellpose-DINO, smaller DINOv3-ViTB backbone); "
+            "or a path to a custom model file."
         ),
     )
     # Neuropil parameters

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,5 +1,5 @@
 # hash:sha256:3a00a2bc08e500660717fdfff02f6cee82dd45a3954fe3e321b9c9d11307981c
-ARG REGISTRY_HOST
+ARG REGISTRY_HOST=registry.codeocean.allenneuraldynamics.org
 FROM $REGISTRY_HOST/codeocean/mambaforge3:24.5.0-0-python3.12.4-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -31,8 +31,8 @@ RUN pip3 install -U --no-cache-dir \
     sbxreader \
     scikit-image \
     sparse \
-    git+https://github.com/AllenNeuralDynamics/aind-ophys-utils.git@v0.2.0#egg=aind-ophys-utils \
-    git+https://github.com/j-friedrich/suite2p.git@save_cellpose_output \
+    aind-ophys-utils==0.2.0 \
+    git+https://github.com/j-friedrich/suite2p.git@save_cellpose_output_v1.1.0 \
     aind-log-utils \
     aind-qcportal-schema
 

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,5 +1,5 @@
 # hash:sha256:3a00a2bc08e500660717fdfff02f6cee82dd45a3954fe3e321b9c9d11307981c
-ARG REGISTRY_HOST=registry.codeocean.allenneuraldynamics.org
+ARG REGISTRY_HOST
 FROM $REGISTRY_HOST/codeocean/mambaforge3:24.5.0-0-python3.12.4-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -24,7 +24,7 @@ RUN pip3 install -U --no-cache-dir \
 
 RUN pip3 install -U --no-cache-dir \
     aind-data-schema==1.1.0 \
-    cellpose==3.0 \
+    cellpose==4.2.1.1 \
     h5py \
     pydantic==2.8.2 \
     pydantic_settings \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,26 +1,20 @@
-# hash:sha256:4bf2c6f19bdc43d3a84be1e8718a293abfbe18f34ed46fef82ed714f8d43c2ac
-FROM registry.codeocean.allenneuraldynamics.org/codeocean/mambaforge3:23.1.0-4-python3.10.12-ubuntu22.04
+# hash:sha256:3a00a2bc08e500660717fdfff02f6cee82dd45a3954fe3e321b9c9d11307981c
+ARG REGISTRY_HOST
+FROM $REGISTRY_HOST/codeocean/mambaforge3:24.5.0-0-python3.12.4-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-
-ENV EXTRACTION_URL=https://github.com/AllenNeuralDynamics/aind-ophys-extraction
-ENV PIPELINE_URL="https://codeocean.allenneuraldynamics.org/capsule/5619253/tree"
-ENV PIPELINE_VERSION="1.0"
-ENV VERSION="5.0"
-
 ARG GIT_ASKPASS
-ARG GIT_ACCESS_TOKEN
 COPY git-ask-pass /
 
-RUN ["apt-get", "update"]
-RUN ["apt-get", "install", "-y", "vim"]
+ENV EXTRACTION_URL=https://github.com/AllenNeuralDynamics/aind-ophys-extraction
+ENV VERSION="15.0"
 
 RUN mamba install -y \
         caiman \
     && mamba clean -ya
 
 RUN pip3 install -U --no-cache-dir \
-    torch --index-url https://download.pytorch.org/whl/cpu
+    torch torchvision --index-url https://download.pytorch.org/whl/cpu
 
 RUN pip3 install -U --no-cache-dir \
     aind-data-schema==1.1.0 \
@@ -31,7 +25,7 @@ RUN pip3 install -U --no-cache-dir \
     sbxreader \
     scikit-image \
     sparse \
-    aind-ophys-utils==0.2.0 \
+    aind-ophys-utils \
     git+https://github.com/j-friedrich/suite2p.git@save_cellpose_output_v1.1.0 \
     aind-log-utils \
     aind-qcportal-schema

--- a/environment/Dockerfile_local
+++ b/environment/Dockerfile_local
@@ -16,4 +16,4 @@ RUN pip3 install -U --no-cache-dir \
     scikit-image \
     sparse \
     aind-ophys-utils \
-    git+https://github.com/j-friedrich/suite2p.git@save_cellpose_output
+    git+https://github.com/j-friedrich/suite2p.git@save_cellpose_output_v1.1.0


### PR DESCRIPTION
## Summary

Suite2p's own pinned fork needed updating to a version that supports Cellpose 4.0's SAM-based models, which required migrating `extraction.py` off Suite2p's old flat-`ops` API onto the new `run_s2p(db, settings)` API (Suite2p 1.0/1.1), and off the pre-4.0 Cellpose API (`Cellpose().sz.eval()`, named model zoo) onto Cellpose-SAM (`CellposeModel`, `cpsam_v2`).

Along the way, several correctness issues were caught and fixed — some introduced by the API changes, some pre-existing and only surfaced by end-to-end smoke testing.

## Suite2p 1.1.0 API migration

- `suite2p.default_ops()` / `run_s2p(ops)` → `suite2p.default_db()` + `suite2p.default_settings()` / `run_s2p(db, settings)`, with all field mappings updated to the new nested `settings["detection"]`, `settings["extraction"]`, `settings["run"]` structure.
- `--suite2p-ops` / `--suite2p-params` CLI overrides reimplemented via a new `apply_suite2p_overrides()` helper, using Suite2p's own `set_settings_orig()` to match flattened legacy key names against the new nested tree.
- Fixed the Cellpose `algorithm`/`img` mapping for cellpose-based init modes (`max/mean`, `mean`, `max`) — previously passed `args.init` straight through, which doesn't match Suite2p's `algorithm` enum (`"sparsery"`/`"sourcery"`/`"cellpose"`) and silently fell back to plain `sourcery` detection instead of running Cellpose at all.
- Dropped the `enhanced_mean` init option — no longer distinguishable from `max_proj` under the new Cellpose image-selection logic, and the numeric (`"1"`/`"2"`/`"3"`/`"4"`) backward-compat aliases were removed along with it.
- Restored `rois/neuropil_coords` output: Suite2p no longer persists a per-ROI neuropil mask in `stat.npy`, so it's recomputed post-hoc via `suite2p.extraction.create_neuropil_masks()`/`create_cell_pix()` using the same settings that were used during extraction.
- Extended diameter auto-estimation (previously `sourcery`-only) to every Suite2p-based init mode — `diameter=0` for cellpose-based modes passed `[0, 0]` into Suite2p, causing a divide-by-zero.

## Cellpose 4.0 (Cellpose-SAM) support

- `pretrained_model` default → `cpsam_v2` (the old named zoo — `cyto`, `cyto2`, etc. — no longer exists in Cellpose 4.x; passing an unrecognized name silently falls back to a default model with only a log warning).
- New `estimate_diameter()` replaces the removed `Cellpose().sz.eval()` SizeModel API by running real Cellpose detection via `suite2p.detection.anatomical.roi_detect()` and reading the `median_diam` it already computes from detected masks — used by both `estimate_gSig()` (CaImAn) and the Suite2p diameter estimate.
- `format_caiman_output`: added a length guard on `cnn_preds` before using it, and fixed `gSig` to round instead of truncate.

## Other fixes found via end-to-end smoke testing

- `save_summary_images_with_rois()` called `plt.close(fig)` referencing an undefined variable (the actual figure is `fix`) — crashed the last step of *every* successful run, regardless of init mode.
- The "no ROIs found" fallback set `iscell = []` (a plain list); downstream code indexes/writes it as a 2D array. Now `np.empty((0, 2), dtype=np.float32)`.
- Restored a dangling `from aind_ophys_utils.segmentation_utils import roi_probabilities` import that had been dropped while the call site remained.

## Environment

- `Dockerfile`: installs `aind-ophys-utils` from PyPI instead of GitHub (published, same version); Cellpose pinned to `4.2.1.1`; Suite2p now installed from `j-friedrich/suite2p@save_cellpose_output_v1.1.0` — a rebase of the `save_cellpose_output` patch onto the upstream `v1.1.0` tag (the old branch predated the 1.0 db/settings rewrite), with a fix for Cellpose 4.x's `model.eval()` returning 3 flow arrays instead of the pre-4.0 API's 4.
- Bumped to a Python 3.12 base image + `torchvision`.

## Testing

Smoke-tested end-to-end in a conda environment replicating the pinned dependency set (real Cellpose 4.2.1.1, the patched Suite2p branch, CaImAn via conda-forge) against a synthetic movie with known ground truth:

- `--init mean` (Cellpose): 33 ROIs detected, 6 correctly classified as cells (0.57–0.92 probability) matching the 6 planted synthetic blobs exactly. `cellpose/*`, `rois/neuropil_coords`, `rois/cellpose_soma_probability` all populated correctly.
- `--init sourcery`: clean full run.
- `--init sparsery`: Suite2p settings/db plumbing verified directly (found 16/16 ROIs on a richer synthetic image); the original small test image just wasn't structured enough for sparsery's own spatial-scale heuristic.
- `--init greedy_roi` (CaImAn): completed fully, validating `estimate_gSig()`'s new Cellpose-based diameter estimate.
- Forced zero-ROI case (blank movie): verified the `iscell` fix — completes cleanly with `iscell` shape `(0, 2)`.

Not covered: the Bergamo branch, `contour_video`, and the `--suite2p-ops`/`--suite2p-params` override mechanism weren't exercised by this testing. The actual Docker image build wasn't verified locally (no Docker in the dev environment used for this work) — CodeOcean has since confirmed the image builds successfully under the Python 3.12 base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)